### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -15,4 +15,4 @@ jobs:
       id-token: write
     steps:
       - id: deployment
-        uses: sphinx-notes/pages@v3
+        uses: sphinx-notes/pages@3.2


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[sphinx-notes/pages](https://github.com/sphinx-notes/pages)** published a new release **[3.2](https://github.com/sphinx-notes/pages/releases/tag/3.2)** on 2025-02-10T13:20:32Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the GitHub Action used for deploying Sphinx documentation to GitHub Pages for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->