### PR TITLE
ci: Update GitHub Actions to Latest Version

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -15,4 +15,4 @@ jobs:
       id-token: write
     steps:
       - id: deployment
-        uses: sphinx-notes/pages@3.2
+        uses: sphinx-notes/pages@3.4


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[sphinx-notes/pages](https://github.com/sphinx-notes/pages)** published a new release **[3.4](https://github.com/sphinx-notes/pages/releases/tag/3.4)** on 2025-07-01T12:11:47Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow for deploying documentation to use a newer version of the deployment action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->